### PR TITLE
Get rid of rawtransactions in process_blocks

### DIFF
--- a/app/sync.py
+++ b/app/sync.py
@@ -136,18 +136,14 @@ def process_transactions(data_db, block_height, pubkeyhash_version, checksum_val
     client = get_active_rpc_client()
 
     try:
-        block = client.getblock(hash_or_height='{}'.format(block_height))['result']
+        block = client.getblock(hash_or_height='{}'.format(block_height), verbose=4)['result']
     except Exception as e:
         log.debug(e)
         return
 
-    for pos_in_block, txid in enumerate(block['tx']):
+    for pos_in_block, tx in enumerate(block['tx']):
         try:
-            tx = client.getrawtransaction(txid, 4)
-            if tx["error"]:
-                log.debug(tx["error"])
-                continue
-            tx_relevant = process_inputs_and_outputs(data_db, tx["result"], pubkeyhash_version, checksum_value)
+            tx_relevant = process_inputs_and_outputs(data_db, tx, pubkeyhash_version, checksum_value)
 
         except Exception as e:
             log.debug(e)
@@ -158,7 +154,7 @@ def process_transactions(data_db, block_height, pubkeyhash_version, checksum_val
             Transaction.create_if_not_exists(
                 data_db,
                 Transaction(
-                    txid=txid,
+                    txid=tx['txid'],
                     pos_in_block=pos_in_block,
                     block=unhexlify(block['hash'])
                 )


### PR DESCRIPTION
The block seem to contain all information needed when
queried from the api with a verbosity of 4